### PR TITLE
M idriss labeler

### DIFF
--- a/.github/.github/label-pr.yml
+++ b/.github/.github/label-pr.yml
@@ -1,0 +1,12 @@
+- regExp: ".*\\.js+$"
+  labels: ["javascript"]
+- regExp: ".*\\.sql+$"
+  labels: ["database", "critical"]
+- regExp: ".*\\.md+$"
+  labels: ["documentation"]
+- regExp: ".*\\.(png|jar|jpg|ico)+$"
+  labels: ["images"]
+- regExp: "^(pom\\.xml|package\\.json|build\\.gradle)$"
+  labels: ["dependencies"]
+- regExp: ".*\\.(zip|jar|war|ear)+$"
+  labels: ["artifact", "invalid"]

--- a/.github/.github/label-pr.yml
+++ b/.github/.github/label-pr.yml
@@ -1,12 +1,12 @@
-- regExp: ".*\\.js+$"
+- regExp: ".*\\.js$"
   labels: ["javascript"]
-- regExp: ".*\\.sql+$"
+- regExp: ".*\\.sql$"
   labels: ["database", "critical"]
-- regExp: ".*\\.md+$"
+- regExp: ".*\\.md$"
   labels: ["documentation"]
-- regExp: ".*\\.(png|jar|jpg|ico)+$"
+- regExp: ".*\\.(png|jar|jpg|ico)$"
   labels: ["images"]
 - regExp: "^(pom\\.xml|package\\.json|build\\.gradle)$"
   labels: ["dependencies"]
-- regExp: ".*\\.(zip|jar|war|ear)+$"
+- regExp: ".*\\.(zip|jar|war|ear)$"
   labels: ["artifact", "invalid"]

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -1,0 +1,22 @@
+# This workflow will triage pull requests and apply a label based on the
+# paths that are modified in the pull request.
+#
+# To use this workflow, you will need to set up a .github/labeler.yml
+# file with configuration.  For more information, see:
+# https://github.com/actions/labeler
+
+name: Labeler
+on: [pull_request_target]
+
+jobs:
+  label:
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+    - uses: actions/labeler@v4
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
This pull request introduces automated labeling for pull requests based on file types and paths. It adds a GitHub Actions workflow to apply labels and provides a configuration file that maps file patterns to specific labels. These changes will help streamline PR triage and improve project organization.

**Automated PR labeling setup:**

* Added a new GitHub Actions workflow (`.github/workflows/label.yml`) to automatically apply labels to pull requests based on changed file paths, using the labeler action.
* Introduced a label configuration file (`.github/.github/label-pr.yml`) that maps file extensions and filenames (such as `.js`, `.sql`, `.md`, images, dependency files, and artifacts) to appropriate labels like `javascript`, `database`, `documentation`, `images`, `dependencies`, and more.