### PR TITLE
feat: update favorite items in English and French JSON files

### DIFF
--- a/assets/styles-enhanced.css
+++ b/assets/styles-enhanced.css
@@ -445,9 +445,9 @@ body:not(.notifications-off) .notifications-toggle .toggle-switch {
 
 .chip-little {
   display: inline-block;
-  margin: var(--space-xs);
+  margin: calc(var(--space-xs) * 0.5);
   font-weight: var(--fw-normal);
-  font-size: var(--font-size-base);
+  font-size: calc(var(--font-size-base) * 0.875);
 }
 
 /* ========================

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -129,12 +129,12 @@
           "description": "Things I enjoy watching/doing.",
           "items": [
             {"name": "Olympique de Marseille", "url": "https://www.om.fr", "linkType": "chip-little"},
-            {"name": "Chess", "url": "https://www.chess.com/member/idriss33345", "linkType": "chip-little"},
-            {"name": "Pizza", "url": "https://www.instagram.com/chateaupizza/", "linkType": "chip-little"},
             {"name": "Age of Empires 2", "url": "https://www.ageofempires.com/games/aoe2de/", "linkType": "chip-little"},
+            {"name": "One Piece", "url": "https://mangaplus.shueisha.co.jp/titles/700005", "linkType": "chip-little"},
+            {"name": "Pizza", "url": "https://www.instagram.com/chateaupizza/", "linkType": "chip-little"},
+            {"name": "Chess", "url": "https://www.chess.com/member/idriss33345", "linkType": "chip-little"},
             {"name": "Scrabble", "url": "https://www.clicmouse.fr/scra/", "linkType": "chip-little"},
-            {"name": "Basic-Fit", "url": "https://www.basic-fit.com", "linkType": "chip-little"},
-            {"name": "One Piece", "url": "https://mangaplus.shueisha.co.jp/titles/700005", "linkType": "chip-little"}
+            {"name": "Basic-Fit", "url": "https://www.basic-fit.com", "linkType": "chip-little"}
           ]
         },
         {

--- a/i18n/fr.json
+++ b/i18n/fr.json
@@ -129,12 +129,12 @@
           "description": "Choses que j'aime regarder/faire.",
           "items": [
             {"name": "Olympique de Marseille", "url": "https://www.om.fr", "linkType": "chip-little"},
-            {"name": "Échecs", "url": "https://www.chess.com/member/idriss33345", "linkType": "chip-little"},
-            {"name": "Pizza", "url": "https://www.instagram.com/chateaupizza/", "linkType": "chip-little"},
             {"name": "Age of Empires 2", "url": "https://www.ageofempires.com/games/aoe2de/", "linkType": "chip-little"},
+            {"name": "One Piece", "url": "https://mangaplus.shueisha.co.jp/titles/700005", "linkType": "chip-little"},
+            {"name": "Pizza", "url": "https://www.instagram.com/chateaupizza/", "linkType": "chip-little"},
+            {"name": "Échecs", "url": "https://www.chess.com/member/idriss33345", "linkType": "chip-little"},
             {"name": "Scrabble", "url": "https://www.clicmouse.fr/scra/", "linkType": "chip-little"},
-            {"name": "Basic-Fit", "url": "https://www.basic-fit.com", "linkType": "chip-little"},
-            {"name": "One Piece", "url": "https://mangaplus.shueisha.co.jp/titles/700005", "linkType": "chip-little"}
+            {"name": "Basic-Fit", "url": "https://www.basic-fit.com", "linkType": "chip-little"}
           ]
         },
         {


### PR DESCRIPTION
This pull request updates the appearance of the `chip-little` UI element and reorganizes the order of items in the "Things I enjoy watching/doing" lists in both English and French translations. The main focus is on improving UI consistency and the presentation of user interests.

**UI Improvements:**

* Adjusted the `chip-little` class in `assets/styles-enhanced.css` to use smaller margins and font sizes for a more compact appearance.

**Content & Localization Updates:**

* Reordered the "Things I enjoy watching/doing" items in both `i18n/en.json` and `i18n/fr.json` to feature "One Piece" earlier in the list, and ensured consistent ordering of "Pizza" and "Chess"/"Échecs". No items were added or removed; only the order changed. [[1]](diffhunk://#diff-1a490f08504158838befaa816ee8d5c08dff9e694d5a568ce4b0a4398dcc563eL132-R137) [[2]](diffhunk://#diff-849e3fab5f8f13d7147af2a08e45ac75945b75506dae850ca68d942a3c34c142L132-R137)