### PR TITLE
🎨 feat: add 'link' class to technology and hobby links for improved sty…

### DIFF
--- a/assets/js/content.js
+++ b/assets/js/content.js
@@ -208,7 +208,7 @@ function createTechStackSection(ldData) {
   html += `<p>Some of the technologies I worked with.</p>`;
 
   html += ldData.knowsAbout.map(tech => {
-    return `<a href="${sanitizeUrl(tech.url)}" target="_blank" rel="noopener noreferrer" class="chip-little">${sanitizeText(tech.name)}</a>`;
+    return `<a href="${sanitizeUrl(tech.url)}" target="_blank" rel="noopener noreferrer" class="chip-little link">${sanitizeText(tech.name)}</a>`;
   }).join('');
   
   container.innerHTML = html;
@@ -284,7 +284,7 @@ function createHobbiesSection(ldData) {
   html += `<p>Things I enjoy watching/doing.</p>`;
 
   html += ldData.hobbies.map(item => {
-    return `<a href="${sanitizeUrl(item.url)}" target="_blank" rel="noopener noreferrer" class="chip-little">${sanitizeText(item.name)}</a>`;
+    return `<a href="${sanitizeUrl(item.url)}" target="_blank" rel="noopener noreferrer" class="chip-little link">${sanitizeText(item.name)}</a>`;
   }).join('');
   
   container.innerHTML = html;


### PR DESCRIPTION
This pull request makes a small styling update to the `createTechStackSection` and `createHobbiesSection` functions in `assets/js/content.js`. The main change is the addition of the `link` class to certain anchor elements, likely to improve or standardize their appearance.

- UI Consistency:
  * Added the `link` CSS class to anchor tags generated for technologies and hobbies, ensuring consistent styling for these links in both the tech stack and hobbies sections. [[1]](diffhunk://#diff-2de343f41e8c9bc4a79c58c52c6170765675f8b437643ca73b7813911a23b97eL211-R211) [[2]](diffhunk://#diff-2de343f41e8c9bc4a79c58c52c6170765675f8b437643ca73b7813911a23b97eL287-R287)