### PR TITLE
fix: remove minimum width constraint for improved responsiveness

### DIFF
--- a/assets/styles-enhanced.css
+++ b/assets/styles-enhanced.css
@@ -636,7 +636,6 @@ body.notifications-off .badge {
   flex: 1;
   color: var(--text-primary);
   width: 100%;
-  min-width: 400px;
   align-items: center;
 }
 


### PR DESCRIPTION
This pull request makes a minor adjustment to the CSS for badges in notification-off mode by removing the minimum width restriction. This change allows badges to be more flexible in their sizing.

- Removed the `min-width: 400px;` property from the `.badge` selector in `assets/styles-enhanced.css`, allowing badges to shrink below 400px when needed.