### PR TITLE
fix: increase minimum height for better layout consistency

### DIFF
--- a/assets/styles-enhanced.css
+++ b/assets/styles-enhanced.css
@@ -200,7 +200,7 @@ textarea:focus,
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  min-height: 50px;
+  min-height: 90px;
   color: var(--text-primary);
   background: var(--glass-bg);
   border: 1px solid var(--glass-border);


### PR DESCRIPTION
This pull request makes a small adjustment to the minimum height of focused textareas in the `assets/styles-enhanced.css` file, increasing it from 50px to 90px to provide more space for user input.