### PR TITLE
chore: remove completed roadmap items for clarity and focus

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -107,8 +107,6 @@ This roadmap outlines the development priorities for the 3dime personal social h
 
 #### 🚀 Advanced Functionality
 - [x] **Analytics Integration** - Privacy-focused analytics (Plausible/Fathom)
-- [ ] **Content Management** - Admin panel for easy content updates
-- [ ] **Social Proof** - Testimonials, recommendations section
 
 #### 🔮 Future Considerations
 - [ ] **Build Process Evaluation** - Consider Vite/Webpack for optimization


### PR DESCRIPTION
This pull request makes a minor update to the project roadmap by removing two planned advanced functionality items. These items were related to content management and social proof features.

- Roadmap update:
  * Removed the "Content Management" (admin panel) and "Social Proof" (testimonials, recommendations) items from the "Advanced Functionality" section in `docs/ROADMAP.md`.