### PR TITLE
fix: increase delay in heatmap loading retry mechanism for improved reliability

### DIFF
--- a/assets/js/heatmap.js
+++ b/assets/js/heatmap.js
@@ -41,7 +41,7 @@ function waitForLibraries(timeout = 10000) {
 /* =========================
    Heatmap Loading with Retry
    ========================= */
-export async function loadHeatmapWithRetry(retries = 3, delay = 1000) {
+export async function loadHeatmapWithRetry(retries = 3, delay = 5000) {
   try {
     // Wait for external libraries to be ready
     await waitForLibraries();

--- a/assets/styles-enhanced.css
+++ b/assets/styles-enhanced.css
@@ -33,7 +33,7 @@
   --space-xs: 0.25rem;
   --space-sm: 0.5rem;
   --space-md: 0.5rem;
-  --space-lg: 0.75rem;
+  --space-lg: 1rem;
   --space-xl: 2rem;
 
   /* Radius */

--- a/assets/styles-enhanced.css
+++ b/assets/styles-enhanced.css
@@ -33,7 +33,7 @@
   --space-xs: 0.25rem;
   --space-sm: 0.5rem;
   --space-md: 0.5rem;
-  --space-lg: 1rem;
+  --space-lg: 0.75rem;
   --space-xl: 2rem;
 
   /* Radius */


### PR DESCRIPTION
This pull request includes minor adjustments to the heatmap loading logic and the CSS spacing variables. The changes are focused on improving user experience by modifying retry timing and refining layout spacing.

Heatmap logic improvements:
* Increased the delay between retries in the `loadHeatmapWithRetry` function from 1 second to 5 seconds, which can help reduce unnecessary rapid retry attempts when external libraries are not immediately available. (`assets/js/heatmap.js`)

Styling refinements:
* Reduced the value of the `--space-lg` CSS variable from `1rem` to `0.75rem` to achieve slightly tighter spacing in the UI. (`assets/styles-enhanced.css`)