### PR TITLE
fix: reduce large spacing variable from 1rem to 0.75rem for improved …

### DIFF
--- a/assets/styles-enhanced.css
+++ b/assets/styles-enhanced.css
@@ -33,7 +33,7 @@
   --space-xs: 0.25rem;
   --space-sm: 0.5rem;
   --space-md: 0.5rem;
-  --space-lg: 1rem;
+  --space-lg: 0.75rem;
   --space-xl: 2rem;
 
   /* Radius */


### PR DESCRIPTION
This pull request makes a minor adjustment to the spacing scale in the CSS variables. The value of `--space-lg` was reduced to better align with the overall spacing system. 

- Reduced `--space-lg` from `1rem` to `0.75rem` in `assets/styles-enhanced.css` to improve spacing consistency.