### PR TITLE
fix: update require paths for services and adjust config file location

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,7 @@ logs/
 coverage/
 
 # PHP configuration files with sensitive credentials
-config.php
+config/config.php
 
 # Web server configuration files
 .htaccess

--- a/config/proxy.php
+++ b/config/proxy.php
@@ -1,8 +1,8 @@
 <?php
 require_once 'config.php';
-require_once 'services/trakt.php';
-require_once 'services/github.php';
-require_once 'services/twitter.php';
+require_once '../services/trakt.php';
+require_once '../services/github.php';
+require_once '../services/twitter.php';
 
 $service = $_GET['service'] ?? '';
 


### PR DESCRIPTION
This pull request updates the import paths for service files in `config/proxy.php` to use relative paths that correctly reference the parent directory. This change improves the reliability of file inclusion and resolves potential path issues.

* Updated the `require_once` statements in `config/proxy.php` to use `../services/` instead of `services/` for loading `trakt.php`, `github.php`, and `twitter.php`.