### PR TITLE
fix: update require paths in proxy.php for improved file referencing

### DIFF
--- a/config/proxy.php
+++ b/config/proxy.php
@@ -1,8 +1,8 @@
 <?php
-require_once 'config.php';
-require_once '../services/trakt.php';
-require_once '../services/github.php';
-require_once '../services/twitter.php';
+require_once __DIR__ . '/config.php';
+require_once __DIR__ . '/../services/trakt.php';
+require_once __DIR__ . '/../services/github.php';
+require_once __DIR__ . '/../services/twitter.php';
 
 $service = $_GET['service'] ?? '';
 


### PR DESCRIPTION
This pull request updates the way required files are included in `config/proxy.php` to use absolute paths, which improves reliability and prevents path-related errors.

Dependency path handling:

* Changed all `require_once` statements in `config/proxy.php` to use `__DIR__` for absolute paths, ensuring correct file inclusion regardless of the current working directory.