### PR TITLE
Revert "Show GitHub activity from all repositories in heatmap instead of single repo (#315)

### DIFF
--- a/assets/js/heatmap.js
+++ b/assets/js/heatmap.js
@@ -162,7 +162,7 @@ function showLoadingState() {
         <div class="spinner" aria-label="Loading heatmap">
           <div class="spinner-circle"></div>
         </div>
-        <p>Loading GitHub activity from all repositories...</p>
+        <p>Loading GitHub activity...</p>
       </div>
     `;
   }
@@ -407,8 +407,8 @@ function renderHeatmap(commitSource) {
         {
           text: function (date, value, dayjsDate) {
             return (
-              (value ? value + ' activities' : 'No activity') +
-              ' across all repositories on ' +
+              (value ? value + ' commits' : 'No commits') +
+              ' on ' +
               dayjsDate.format('LL')
             );
           },

--- a/docs/PHP_SETUP_GUIDE.md
+++ b/docs/PHP_SETUP_GUIDE.md
@@ -50,7 +50,7 @@ php -S localhost:8000
 # Test GitHub API proxy
 curl "http://localhost:8000/proxy.php?service=github"
 
-# Test commit data for heatmap (shows activity from all repositories)
+# Test commit data for heatmap
 curl "http://localhost:8000/proxy.php?service=github&type=commits"
 ```
 
@@ -109,9 +109,9 @@ sudo systemctl start php7.4-fpm nginx
 
 **GitHub Heatmap Not Loading**:
 - Ensure `config.php` exists (copy from `config.php.example`)
-- Set `GITHUB_USERNAME` in config.php (GITHUB_REPO is no longer required as we fetch from all repositories)
+- Set `GITHUB_USERNAME` and `GITHUB_REPO` in config.php
 - Add `GITHUB_TOKEN` for higher rate limits (optional but recommended)
-- Check that user events endpoint works: `curl "yoursite.com/proxy.php?service=github&type=commits"`
+- Check that commit data endpoint works: `curl "yoursite.com/proxy.php?service=github&type=commits"`
 
 **CORS Errors**:
 - Ensure `proxy.php` includes proper CORS headers

--- a/services/GITHUB_API_DOCS.md
+++ b/services/GITHUB_API_DOCS.md
@@ -21,25 +21,6 @@ define('GITHUB_REPO', '3dime');
 
 ## API Endpoints
 
-### User Activity (Heatmap Data) - Updated
-```
-GET /proxy.php?service=github&type=commits
-```
-
-**Returns activity from ALL user repositories** (changed from single repository):
-```json
-{
-  "commit_activity": [
-    {
-      "week": 1640908800,
-      "days": [2, 0, 1, 3, 0, 0, 1]
-    }
-  ]
-}
-```
-
-This endpoint now uses the GitHub User Events API (`/users/{username}/events/public`) to aggregate activity across all repositories, providing a comprehensive view of the user's GitHub activity rather than just one specific repository.
-
 ### User Statistics
 ```
 GET /proxy.php?service=github


### PR DESCRIPTION
This pull request reverts the heatmap's data source from aggregating activity across all user repositories (via the GitHub User Events API) back to using the per-repository commit activity endpoint (`/stats/commit_activity`). The changes update both the backend PHP code and the frontend/user documentation to reflect this shift, ensuring that the heatmap now only visualizes commit activity from a single specified repository.

**Backend (PHP) changes:**

* Switched the `commits` data source in `github.php` from the User Events API (`/users/{username}/events/public`) back to the per-repository Commit Activity API (`/repos/{username}/{repo}/stats/commit_activity`). Removed the logic for aggregating events across all repositories, and now directly returns the commit activity data as received from GitHub. [[1]](diffhunk://#diff-a3b520d4aa7e8a10d8879012f60833490e0c0300b05245febb79d3317ae4bf1fL24-R24) [[2]](diffhunk://#diff-a3b520d4aa7e8a10d8879012f60833490e0c0300b05245febb79d3317ae4bf1fL192-R197) [[3]](diffhunk://#diff-a3b520d4aa7e8a10d8879012f60833490e0c0300b05245febb79d3317ae4bf1fL205-L278)
* Improved handling for the 202 HTTP response from the Commit Activity API, which indicates that GitHub is still computing statistics. The code now retries appropriately and provides clearer error messages when stats are not ready. [[1]](diffhunk://#diff-a3b520d4aa7e8a10d8879012f60833490e0c0300b05245febb79d3317ae4bf1fL41-R46) [[2]](diffhunk://#diff-a3b520d4aa7e8a10d8879012f60833490e0c0300b05245febb79d3317ae4bf1fL166-R169)

**Frontend and documentation updates:**

* Updated user-facing messages and tooltips in `heatmap.js` to remove references to "all repositories" and clarify that the heatmap shows commit activity, not general activity. [[1]](diffhunk://#diff-f13df7f98e178c3d14a018d9fbf7cae174410e5259b346b66af1ec4b31b2d964L165-R165) [[2]](diffhunk://#diff-f13df7f98e178c3d14a018d9fbf7cae174410e5259b346b66af1ec4b31b2d964L410-R411)
* Revised setup and troubleshooting instructions in `PHP_SETUP_GUIDE.md` to require both `GITHUB_USERNAME` and `GITHUB_REPO`, and clarified that the heatmap now shows commit data from a single repository. [[1]](diffhunk://#diff-08e3e2227d72f2962184dcf729cffa94e51f981e39373002d4885e0f1921f063L53-R53) [[2]](diffhunk://#diff-08e3e2227d72f2962184dcf729cffa94e51f981e39373002d4885e0f1921f063L112-R114)
* Removed outdated documentation in `GITHUB_API_DOCS.md` that described the aggregation of activity across all repositories.

These changes ensure that the heatmap accurately reflects commit activity from the configured repository only, improving clarity and aligning with the revised backend implementation.