### PR TITLE
refactor: return full user data instead of selected fields in github.php

### DIFF
--- a/services/github.php
+++ b/services/github.php
@@ -187,12 +187,7 @@ function executeGitHubApiCall($apiUrl, $type) {
     } elseif ($type === 'list') {
         return $data;
     } else {
-        return [
-            'user_id' => $data['id'] ?? 0,
-            'repos' => $data['public_repos'] ?? 0,
-            'followers' => $data['followers'] ?? 0,
-            'following' => $data['following'] ?? 0
-        ];
+        return $data;
     }
 }
 


### PR DESCRIPTION
This pull request makes a small change to the `executeGitHubApiCall` function in `services/github.php`. Instead of returning a filtered array with selected user properties for non-list API calls, the function now returns the full `$data` object as-is.