### PR TITLE
Datas social

### DIFF
--- a/services/github.php
+++ b/services/github.php
@@ -24,6 +24,8 @@ function fetchGithubData($type = 'user', $repo = null) {
         $apiUrl = "https://api.github.com/repos/$username/$repo/stats/commit_activity";
     } elseif ($type === 'list') {
         $apiUrl = "https://api.github.com/users/$username/repos";
+    } elseif ($type === 'social') {
+        $apiUrl = "https://api.github.com/users/$username/social_accounts";
     } else {
         $apiUrl = "https://api.github.com/users/$username";
     }

--- a/services/github.php
+++ b/services/github.php
@@ -187,12 +187,7 @@ function executeGitHubApiCall($apiUrl, $type) {
     } elseif ($type === 'list') {
         return $data;
     } else {
-        return [
-            'user_id' => $data['id'] ?? 0,
-            'repos' => $data['public_repos'] ?? 0,
-            'followers' => $data['followers'] ?? 0,
-            'following' => $data['following'] ?? 0
-        ];
+        return $data;
     }
 }
 


### PR DESCRIPTION
This pull request updates the GitHub data fetching logic in `services/github.php` to support retrieving user social account information and simplifies the data returned for most API calls. The most important changes are:

**Feature Addition:**

* Added support for fetching a user's social accounts by introducing a new `$type` value `'social'` in the `fetchGithubData` function, which calls the appropriate GitHub API endpoint.

**Code Simplification:**

* Updated the `executeGitHubApiCall` function to return the raw API response data for most `$type` values instead of mapping specific fields, making the function more flexible and consistent.